### PR TITLE
Update CCNode.m

### DIFF
--- a/cocos2d/CCNode.m
+++ b/cocos2d/CCNode.m
@@ -549,8 +549,10 @@ static NSUInteger globalOrderOfArrival = 1;
 
 	kmGLPushMatrix();
 
-	if ( _grid && _grid.active)
+	if ( _grid && _grid.active) {
 		[_grid beforeDraw];
+		[self transformAncestors];
+	}
 
 	[self transform];
 


### PR DESCRIPTION
Fixes the case when an action runs on a node and the node "loses" its properties before the action was run. 

Example: A node is child of a layer that is scaled (CCScaleTo action), and the node doesn't scale. Same for CCMoveTo applied to the parent layer, the child node stays in the same place. This affects only the nodes that previously ran another action (even if the action was stopped).
